### PR TITLE
[BUGFIX] __construct: added try catch block

### DIFF
--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -34,7 +34,14 @@ class TwigRenderer {
     if (isset($this->config['src']['namespaces'])) {
       foreach ($this->config['src']['namespaces'] as $namespace) {
         foreach ($namespace['paths'] as $path) {
-          $this->loader->addPath($path, $namespace['id']);
+          // The twigRenderer tries to access paths which 
+          // might be not present anymore. In that case we 
+          // have to catch this
+          try {
+            $this->loader->addPath($path, $namespace['id']);
+          } catch (Throwable $e) {
+            // ignore
+          }
         }
       }
     }


### PR DESCRIPTION
I'm using twigRenderer with patternLab Node 3.0.5. I've frequently issues with a dying watcher because of a fatal error coming from this part. A Try catch block fixed this.

```
PHP Fatal error:  Uncaught Twig_Error_Loader: The "source/_patterns/00-atoms/btn-3" directory does not exist ("/app/source/_patterns/00-atoms/btn-3"). in /app/node_modules/@basalt/twig-renderer/vendor/twig/twig/lib/Twig/Loader/Filesystem.php:101
build_1  | Stack trace:
build_1  | #0 /app/node_modules/@basalt/twig-renderer/dist/TwigRenderer.php(37): Twig_Loader_Filesystem->addPath('source/_pattern...', 'atoms')
build_1  | #1 /app/node_modules/@basalt/twig-renderer/dist/server--async.php(46): BasaltInc\TwigRenderer\TwigRenderer->__construct(Array)
build_1  | #2 {main}
build_1  |   thrown in /app/node_modules/@basalt/twig-renderer/vendor/twig/twig/lib/Twig/Loader/Filesystem.php on line 101
```